### PR TITLE
Give docker CI workflow a proper build name

### DIFF
--- a/.github/workflows/docker_intel.yml
+++ b/.github/workflows/docker_intel.yml
@@ -8,8 +8,9 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
 
+  docker_build:
+    name: Docker Intel Build
     runs-on: ubuntu-20.04
 
     steps:


### PR DESCRIPTION
Rename the docker CI build to make it have a proper name in the branch rules.